### PR TITLE
Dashboard: Fix shutdown button rebooting instead shudown

### DIFF
--- a/core/web/modules/services/includes/panels/system.inc.php
+++ b/core/web/modules/services/includes/panels/system.inc.php
@@ -41,7 +41,7 @@ class SystemPanel extends Panel {
                     }
                     poweroff = function() {
                         var message = "<strong>' . _T("The server will be poweroff. Are you sure ?", "services") . '</strong>";
-                        var url = "' . urlStrRedirect('services/control/reboot') . '";
+                        var url = "' . urlStrRedirect('services/control/poweroff') . '";
                         displayConfirmationPopup(message, url);
                     }
                 </script>


### PR DESCRIPTION
In dashboard, the shutdown button was sending a reboot command.