### PR TITLE
To avoid PHP warning

### DIFF
--- a/pulse2/web/modules/msc/msc/package_detail.php
+++ b/pulse2/web/modules/msc/msc/package_detail.php
@@ -31,7 +31,7 @@ $pid = $_GET["pid"];
 $p_api = new ServerAPI();
 $p_api->fromURI($_GET["papi"]);
 $details = getPackageDetails($p_api, $_GET["pid"]);
-$name = $details['name'];
+$name = $details['label'];
 
 $a_param = array(_T("Label", 'msc'), _T("Version", 'msc'), _T('Command', 'msc'));
 $a_value = array($details['label'], $details['version'], $details['command']['command']);


### PR DESCRIPTION
I don't have name to the first level
[preCommand] array
[basepath] [label] [do_reboot] [version] string
[commande] array
[postCommandeFailure] array
[id] string
[size] integer

Error is : Undefined index: name in... line 34

This correction fix PHP warning and diffusion still working (test on 1.5.6)