### PR TITLE
pulse: update agents download urls

### DIFF
--- a/pulse2/services/clients/templates/mac/package/Contents/Resources/postflight.in
+++ b/pulse2/services/clients/templates/mac/package/Contents/Resources/postflight.in
@@ -46,7 +46,7 @@ inv_server_tag=$(sed '2q;d' ${inv_file})
 
 fusion_version="2.2.7-3"
 fusion_archive=fusioninventory-agent_macosx-intel_${fusion_version}.pkg.tar.gz
-fusion_url=https://www.dropbox.com/sh/qdrpsttj8tqsn2q/AAC141YHO3YS1Quvobv9Bq_Ga/inventory-agent/${fusion_archive}
+fusion_url=http://repo.pulse2.fr/pub/pulse2/client/mac/inventory-agent/${fusion_archive}
 fusion_pkg="FusionInventory-Agent.pkg"
 fusion_cfg=/opt/fusioninventory-agent/agent.cfg
 ssh_pub_key="${PREFIX}/id_rsa.pub"

--- a/pulse2/services/clients/win32/generate-agent-pack.sh.in
+++ b/pulse2/services/clients/win32/generate-agent-pack.sh.in
@@ -44,16 +44,16 @@ inv_file=inventory-agent-${inv_ver}.exe
 sfx_file=7zsd.sfx
 
 # Main win32 download folder
-# https://www.dropbox.com/sh/wu6o0nmcgsq7b6d/AAB6x1z2466gMSHdqdj4aKT_a/win32
+# http://repo.pulse2.fr/pub/pulse2/client/windows/win32
 
 # Main mac download folder
-# https://www.dropbox.com/sh/qdrpsttj8tqsn2q/AAC4AN0h_TKtfkRocQawQQMHa
+# http://repo.pulse2.fr/pub/pulse2/client/mac
 
 # Compute downloads url
-ssh_url=https://www.dropbox.com/sh/wu6o0nmcgsq7b6d/AAAf_GsqCWFweOSSgnT0lGY-a/win32/pulse2-secure-agent/${ssh_file}
-vnc_url=https://www.dropbox.com/sh/wu6o0nmcgsq7b6d/AAC2EwQKH2DWv6cl6wq9z7aXa/win32/pulse2-rda-agent/${vnc_file}
-inv_url=https://www.dropbox.com/sh/wu6o0nmcgsq7b6d/AADiKKkV5FWgTZNS56h_2RFra/win32/inventory-agent/${inv_file}
-sfx_url=https://www.dropbox.com/sh/wu6o0nmcgsq7b6d/AADRiFpDVy4QLgOVTvW_7nqOa/win32/${sfx_file}
+ssh_url=http://repo.pulse2.fr/pub/pulse2/client/windows/win32/pulse2-secure-agent/${ssh_file}
+vnc_url=http://repo.pulse2.fr/pub/pulse2/client/windows/win32/pulse2-rda-agent/${vnc_file}
+inv_url=http://repo.pulse2.fr/pub/pulse2/client/windows/win32/inventory-agent/${inv_file}
+sfx_url=http://repo.pulse2.fr/pub/pulse2/client/windows/win32/${sfx_file}
 msi_webservice_url=http://msi-agents.mandriva.com/
 
 # Command line options handling


### PR DESCRIPTION
Pointed out Pulse win32 and mac binaries to the Pulse² Repository

Main win32 download folder
http://repo.pulse2.fr/pub/pulse2/client/windows/win32

Main mac download folder
http://repo.pulse2.fr/pub/pulse2/client/mac