### PR TITLE
MMC - Fix MySQL not started while mmc-agent starts at boot

### DIFF
--- a/core/agent/init/mmc-agent.in
+++ b/core/agent/init/mmc-agent.in
@@ -19,7 +19,7 @@
 # along with MMC.  If not, see <http://www.gnu.org/licenses/>.
 ### BEGIN INIT INFO
 # Provides:          mmc-agent
-# Required-Start:    $remote_fs slapd
+# Required-Start:    $remote_fs slapd mysql
 # Required-Stop:     slapd
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6


### PR DESCRIPTION
Error reported while rebooting server
```
2015-09-22 19:44:33,717 #-1218898240 INFO mmc-agent 3.1.83 starting...
2015-09-22 19:44:33,717 #-1218898240 INFO Using Python 2.7.3 (default, Mar 14 2014, 11:57:14)
2015-09-22 19:44:33,718 #-1218898240 INFO Using Python Twisted 12.0.0
2015-09-22 19:44:33,718 #-1218898240 INFO Multi-threading enabled, max threads pool size is 20
2015-09-22 19:44:33,731 #-1218898240 INFO Importing available MMC plugins
2015-09-22 19:44:33,767 #-1218898240 INFO This version is a community version.
2015-09-22 19:44:33,767 #-1218898240 INFO Plugin base loaded, version: 3.1.83
2015-09-22 19:44:33,822 #-1218898240 INFO BackupPC database is connecting
2015-09-22 19:44:33,830 #-1218898240 ERROR Can't connect to the database: (2002, "Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (2)")
2015-09-22 19:44:33,831 #-1218898240 ERROR Error while creating cursor: 'NoneType' object has no attribute 'cursor'
2015-09-22 19:44:33,831 #-1218898240 ERROR Error while trying to load plugin backuppc
2015-09-22 19:44:33,831 #-1218898240 ERROR 'NoneType' object has no attribute 'execute'
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/mmc/agent.py", line 903, in loadPlugin
    if (func()):
  File "plugins/backuppc/__init__.py", line 68, in activate
    if not BackuppcDatabase().activate(config):
  File "/usr/lib/python2.7/dist-packages/pulse2/database/backuppc/__init__.py", line 65, in activate
    if not self.db_check():
  File "/usr/lib/python2.7/dist-packages/pulse2/database/backuppc/__init__.py", line 55, in db_check
    return DatabaseHelper.db_check(self)
  File "/usr/lib/python2.7/dist-packages/mmc/database/database_helper.py", line 66, in db_check
    return self.db_update()
  File "/usr/lib/python2.7/dist-packages/mmc/database/database_helper.py", line 86, in db_update
    return db_control.process()
  File "/usr/lib/python2.7/dist-packages/mmc/database/ddl.py", line 379, in process
    if not self.db_exists:
  File "/usr/lib/python2.7/dist-packages/mmc/database/ddl.py", line 306, in db_exists
    c.execute(statement)
AttributeError: 'NoneType' object has no attribute 'execute'
2015-09-22 19:44:33,834 #-1218898240 WARNING Plugin ppolicy: disabled by configuration.
2015-09-22 19:44:33,834 #-1218898240 WARNING Plugin ppolicy not loaded.
2015-09-22 19:44:33,896 #-1218898240 WARNING Plugin inventory: disabled by configuration.
2015-09-22 19:44:33,896 #-1218898240 WARNING Plugin inventory not loaded.
....
```
Adding mysql in the required-start directive fix the problem

```
2015-09-22 19:47:24,975 #-1219307840 INFO mmc-agent 3.1.83 starting...
2015-09-22 19:47:24,975 #-1219307840 INFO Using Python 2.7.3 (default, Mar 14 2014, 11:57:14)
2015-09-22 19:47:24,975 #-1219307840 INFO Using Python Twisted 12.0.0
2015-09-22 19:47:24,975 #-1219307840 INFO Multi-threading enabled, max threads pool size is 20
2015-09-22 19:47:25,072 #-1219307840 INFO Importing available MMC plugins
2015-09-22 19:47:25,171 #-1219307840 INFO This version is a community version.
2015-09-22 19:47:25,171 #-1219307840 INFO Plugin base loaded, version: 3.1.83
2015-09-22 19:47:25,280 #-1219307840 INFO BackupPC database is connecting
2015-09-22 19:47:25,329 #-1219307840 INFO Plugin backuppc loaded, version: 3.0
2015-09-22 19:47:25,338 #-1219307840 WARNING Plugin ppolicy: disabled by configuration.
2015-09-22 19:47:25,340 #-1219307840 WARNING Plugin ppolicy not loaded.
2015-09-22 19:47:25,470 #-1219307840 WARNING Plugin inventory: disabled by configuration.
2015-09-22 19:47:25,470 #-1219307840 WARNING Plugin inventory not loaded.
2015-09-22 19:47:26,012 #-1219307840 INFO Report database is connecting
2015-09-22 19:47:26,260 #-1219307840 INFO Plugin report loaded, version: 3.1.83
2015-09-22 19:47:26,300 #-1219307840 INFO Glpi is activating
2015-09-22 19:47:26,550 #-1219307840 INFO Glpi is in version 0.85.5
2015-09-22 19:47:26,613 #-1219307840 INFO Plugin glpi loaded, version: 3.0
2015-09-22 19:47:26,614 #-1219307840 INFO Plugin dashboard loaded, version: 3.1.83
2015-09-22 19:47:26,617 #-1219307840 INFO Dyngroup database is connecting
2015-09-22 19:47:26,680 #-1219307840 INFO Plugin dyngroup loaded, version: 3.0
2015-09-22 19:47:26,714 #-1219307840 INFO Plugin pkgs loaded, version: 3.0
2015-09-22 19:47:26,716 #-1219307840 INFO Msc database is connecting
2015-09-22 19:47:26,769 #-1219307840 INFO Plugin msc loaded, version: 3.0
2015-09-22 19:47:26,775 #-1219307840 WARNING Plugin services: disabled by configuration.
...
```